### PR TITLE
Update string-interner dependency to newest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.0.1"
 textplots = "0.5.1"
 parse-display = "0.1.2"
 
-string-interner = "0.10"
+string-interner = "0.11"
 lasso = "0.3"
 lalrpop-intern = "0.15"
 intaglio = "1.1"


### PR DESCRIPTION
Version `0.11` of the `string-interner` crate significantly reduces overall memory consumption and increases internment throughput.

Link to crate: https://crates.io/crates/string-interner

For `string-interner` version `0.12` it is planned to add yet another pluggable backend that is inspired directly by `strena`. Btw.: The plotter always just plots "THIS LIB" instead of the library name.

Looking at the stats it seems that `string-interner` actually uses even less memory than `lasso`. :partying_face: 

```
     total events | 66
      peak bytes  | 319.9 KB
     ----------------------------
     alloc events | 41
     alloc bytes  | 492.3 KB
     ----------------------------
     freed events | 25
     freed bytes  | 213.4 KB
```

![2020-07-14-195847_2117x1132_scrot](https://user-images.githubusercontent.com/8193155/87460023-7a2e8e00-c60c-11ea-8896-cefe331b29ca.png)
